### PR TITLE
[sdk-vpp#370] Use abstract sockets for memif

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,3 +17,8 @@ require (
 	google.golang.org/grpc v1.38.0
 	gopkg.in/yaml.v2 v2.4.0
 )
+
+replace (
+	github.com/networkservicemesh/api => github.com/Bolodya1997/api v0.0.0-20211103052554-ef6f03fec39e
+	github.com/networkservicemesh/sdk-vpp => github.com/Bolodya1997/sdk-vpp v0.0.0-20211103055450-1b016e8dd77e
+)

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,10 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 git.fd.io/govpp.git v0.3.6-0.20210202134006-4c1cccf48cd1/go.mod h1:OCVd4W8SH+666KRQoMj6PM+oipLDZAHhqMz9B1TGbgI=
 git.fd.io/govpp.git v0.3.6-0.20210927044411-385ccc0d8ba9 h1:QFHVGWCWf6e226vMy1zU614eC3glrfJO2CwREUk8D6s=
 git.fd.io/govpp.git v0.3.6-0.20210927044411-385ccc0d8ba9/go.mod h1:OCVd4W8SH+666KRQoMj6PM+oipLDZAHhqMz9B1TGbgI=
+github.com/Bolodya1997/api v0.0.0-20211103052554-ef6f03fec39e h1:PAVx2UPtiop2fRDK4GnvHZEVuDNFI4j1ojVC8a6YldQ=
+github.com/Bolodya1997/api v0.0.0-20211103052554-ef6f03fec39e/go.mod h1:B6meq/SWjWR6bGXZdXPfbOeaBK+T1JayLdtEJQCsXKU=
+github.com/Bolodya1997/sdk-vpp v0.0.0-20211103055450-1b016e8dd77e h1:NDElsDaObe7WhAiXSkR12DQzyQug/XVdrji3WVciyx4=
+github.com/Bolodya1997/sdk-vpp v0.0.0-20211103055450-1b016e8dd77e/go.mod h1:vZiXD1iPzX9/UpjJdny/wo3QG+47zPDKqvN6UXVtknE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1 h1:GX8GAYDuhlFQnI2fRDHQhTlkHMz8bEn0jTI6LJU0mpw=
@@ -157,13 +161,10 @@ github.com/nats-io/nkeys v0.2.0/go.mod h1:XdZpAbhgyyODYqjTawOnIOI7VlbKSarI9Gfy1t
 github.com/nats-io/nkeys v0.3.0/go.mod h1:gvUNGjVcM2IPr5rCsRsC6Wb3Hr2CQAm08dsxtV6A5y4=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nats-io/stan.go v0.10.0/go.mod h1:0jEuBXKauB1HHJswHM/lx05K48TJ1Yxj6VIfM4k+aB4=
-github.com/networkservicemesh/api v1.0.1-0.20210907194827-9a36433d7d6e h1:PO6tDo/bGLJqz1qiqCecht/HqMWCKunAds2U9Hvc0yM=
-github.com/networkservicemesh/api v1.0.1-0.20210907194827-9a36433d7d6e/go.mod h1:B6meq/SWjWR6bGXZdXPfbOeaBK+T1JayLdtEJQCsXKU=
 github.com/networkservicemesh/sdk v0.5.1-0.20211102193303-a94a249e2f5f h1:eukVjhE/VfbWFBIyCdEAavJ0I1Rn35xD2FQNVuSALqk=
 github.com/networkservicemesh/sdk v0.5.1-0.20211102193303-a94a249e2f5f/go.mod h1:Y9dl3Y4VS+g5oIGQCr3n8fIDQmrPBxi2MD9Yz8ouCKA=
+github.com/networkservicemesh/sdk-kernel v0.0.0-20211102193653-c878506a3577 h1:/WMqdzruFAVQfmDGLjdiu2PpY3120zntXGL70LnOx3M=
 github.com/networkservicemesh/sdk-kernel v0.0.0-20211102193653-c878506a3577/go.mod h1:tO0QpDJeTAwJdfwOhrPmodozLTsfdQZDxwEMXwlrepw=
-github.com/networkservicemesh/sdk-vpp v0.0.0-20211102193945-44183deea8a5 h1:nV9n5H9s9dPj+HJc4eSrfyOotWlAQ9NKd/ijMNLGZg4=
-github.com/networkservicemesh/sdk-vpp v0.0.0-20211102193945-44183deea8a5/go.mod h1:86i8VjxCvIYgyPite91Ly4DoN21Ni93Wo+Pxu3BhhAw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
@@ -222,6 +223,7 @@ github.com/uber/jaeger-lib v2.4.0+incompatible h1:fY7QsGQWiCt8pajv4r7JEvmATdCVaW
 github.com/uber/jaeger-lib v2.4.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
+github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/yashtewari/glob-intersection v0.0.0-20180916065949-5c77d914dd0b h1:vVRagRXf67ESqAb72hG2C/ZwI8NtJF2u2V76EsuOHGY=
 github.com/yashtewari/glob-intersection v0.0.0-20180916065949-5c77d914dd0b/go.mod h1:HptNXiXVDcJjXe9SqMd0v2FsL9f8dz4GnXgltU6q/co=

--- a/main.go
+++ b/main.go
@@ -200,7 +200,9 @@ func main() {
 			xconnect.NewServer(vppConn),
 			acl.NewServer(vppConn, config.ACLConfig),
 			mechanisms.NewServer(map[string]networkservice.NetworkServiceServer{
-				memif.MECHANISM: chain.NewNetworkServiceServer(memif.NewServer(vppConn)),
+				memif.MECHANISM: chain.NewNetworkServiceServer(
+					memif.NewServer(ctx, vppConn),
+				),
 			}),
 			connect.NewServer(
 				client.NewClient(


### PR DESCRIPTION
## Description
Starts using `memif` with abstract sockets.

Depends on https://github.com/networkservicemesh/api/pull/113.
Depends on https://github.com/networkservicemesh/sdk-vpp/pull/369.
Depends on https://github.com/edwarnicke/vpphelper/pull/13.

## Issue link
networkservicemesh/sdk-vpp#370

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
