### PR TITLE
Update go to 1.18

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -101,7 +101,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.18
       - name: Update version manually
         run: |
           branch=${{ needs.automerge.outputs.pr_branch_ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.18
       - name: Build
         run: go build -race ./...
 
@@ -55,11 +55,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.18
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.35.0
+          version: v1.45.2
 
   excludeFmtErrorf:
     name: exclude fmt.Errorf
@@ -80,13 +80,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Restrict dependencies on github.com/networkservicemesh/*
         env:
-          ALLOWED_REPOSITORIES: "api, sdk, sdk-k8s, sdk-kernel, sdk-sriov, sdk-vpp"
+          ALLOWED_REPOSITORIES: "api sdk sdk-k8s sdk-kernel sdk-sriov sdk-vpp"
+
         run: |
-          for i in $(grep github.com/networkservicemesh/ go.mod | grep -v '^module' | sed 's;.*\(github.com\/networkservicemesh\/[^ ]*\).*;\1;g');do
-            if ! [ "$(echo ${ALLOWED_REPOSITORIES} | grep ${i#github.com/networkservicemesh/})" ]; then
-              echo Dependency on "${i}" is forbidden
-              exit 1
-            fi;
+          for i in $(grep -v '// indirect' go.mod | gsed -n 's:^\tgithub.com/networkservicemesh/\([^ ]\+\) .*:\1:p'); do
+            ! [[ " $ALLOWED_REPOSITORIES " =~ " $i " ]] || continue
+            echo Dependency on "${i}" is forbidden
+            exit 1
           done
 
   checkgomod:
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.18
       - run: go mod tidy
       - name: Check for changes
         run: |
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.18
       - run: go generate ./...
       - name: Check for changes
         run: |
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.18
       - name: Build container
         run: docker build .
       - name: Run tests

--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.18
       - name: Build ${NAME}:${GITHUB_SHA::8} image
         run: docker build . -t "${ORG}/${NAME}:${GITHUB_SHA::8}" --target runtime
       - name: Build ${NAME}:latest image

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 .idea/
 junit/
+
+# Installed tools listed in tools.go
+/.bin

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,8 +10,9 @@ linters-settings:
     values:
       regexp:
         company: .*
-        copyright-holder: Copyright \(c\) ({{year-range}}) {{company}}\n\n
-        copyright-holders: ({{copyright-holder}})+
+        copyright-holder-curr: Copyright \(c\) ({{year-range}}) {{company}}\n\n
+        copyright-holder: Copyright \(c\) .*\n\n
+        copyright-holders: ({{copyright-holder}})*({{copyright-holder-curr}})+({{copyright-holder}})*
   errcheck:
     check-type-assertions: false
     check-blank: false
@@ -24,7 +25,7 @@ linters-settings:
           - (github.com/sirupsen/logrus.FieldLogger).Warnf
           - (github.com/sirupsen/logrus.FieldLogger).Errorf
           - (github.com/sirupsen/logrus.FieldLogger).Fatalf
-  golint:
+  revive:
     min-confidence: 0.8
   goimports:
     local-prefixes: github.com/networkservicemesh
@@ -143,7 +144,7 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
+    - revive
     - gosec
     - gosimple
     - govet
@@ -152,7 +153,7 @@ linters:
     # - lll
     - misspell
     - nakedret
-    - scopelint
+    - exportloopref
     - staticcheck
     - structcheck
     - stylecheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,23 @@
 ARG VPP_VERSION=v22.06-rc0-147-gb2b1a4ad2
 FROM ghcr.io/edwarnicke/govpp/vpp:${VPP_VERSION} as go
-COPY --from=golang:1.16.3-buster /usr/local/go/ /go
+COPY --from=golang:1.18-bullseye /usr/local/go/ /go
 ENV PATH ${PATH}:/go/bin
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOBIN=/bin
 RUN rm -r /etc/vpp
-RUN go get github.com/go-delve/delve/cmd/dlv@v1.6.0
-RUN go get github.com/edwarnicke/dl
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.6.0
+RUN go install github.com/edwarnicke/dl@latest
 RUN dl https://github.com/spiffe/spire/releases/download/v0.11.1/spire-0.11.1-linux-x86_64-glibc.tar.gz | \
     tar -xzvf - -C /bin --strip=3 ./spire-0.11.1/bin/spire-server ./spire-0.11.1/bin/spire-agent
 
 FROM go as build
 WORKDIR /build
 COPY go.mod go.sum ./
-COPY ./internal/imports ./internal/imports
+COPY ./internal/imports internal/imports
 RUN go build ./internal/imports
 COPY . .
-RUN go build -o /bin/app .
+RUN go build -buildvcs=false -o /bin/app .
 
 FROM build as test
 CMD go test -test.v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module github.com/networkservicemesh/cmd-template
 
-go 1.16
+go 1.18
 
 require (
 	github.com/antonfisher/nested-logrus-formatter v1.3.1
 	github.com/edwarnicke/govpp v0.0.0-20220311182453-f32f292e0e91
 	github.com/edwarnicke/grpcfd v1.1.2
+	github.com/edwarnicke/imports-gen v1.1.2
 	github.com/edwarnicke/vpphelper v0.0.0-20210512223648-f914b171f679
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/networkservicemesh/api v1.3.0-rc.1.0.20220405210054-fbcde048efa5
@@ -16,4 +17,55 @@ require (
 	github.com/spiffe/go-spiffe/v2 v2.0.0
 	google.golang.org/grpc v1.42.0
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	git.fd.io/govpp.git v0.3.6-0.20210927044411-385ccc0d8ba9 // indirect
+	github.com/OneOfOne/xxhash v1.2.3 // indirect
+	github.com/cenkalti/backoff/v4 v4.1.2 // indirect
+	github.com/edwarnicke/exechelper v1.0.2 // indirect
+	github.com/edwarnicke/log v1.0.0 // indirect
+	github.com/edwarnicke/serialize v1.0.7 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-logr/logr v1.2.1 // indirect
+	github.com/go-logr/stdr v1.2.0 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/golang-jwt/jwt/v4 v4.1.0 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/lunixbochs/struc v0.0.0-20200521075829-a4cb8d33dbbe // indirect
+	github.com/networkservicemesh/sdk-kernel v0.0.0-20220415125717-fb284fbe9fc1 // indirect
+	github.com/open-policy-agent/opa v0.16.1 // indirect
+	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
+	github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74 // indirect
+	github.com/yashtewari/glob-intersection v0.0.0-20180916065949-5c77d914dd0b // indirect
+	github.com/zeebo/errs v1.2.2 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.27.0 // indirect
+	go.opentelemetry.io/otel v1.3.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.3.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.26.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.26.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.3.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.3.0 // indirect
+	go.opentelemetry.io/otel/internal/metric v0.26.0 // indirect
+	go.opentelemetry.io/otel/metric v0.26.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.3.0 // indirect
+	go.opentelemetry.io/otel/sdk/export/metric v0.26.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v0.26.0 // indirect
+	go.opentelemetry.io/otel/trace v1.3.0 // indirect
+	go.opentelemetry.io/proto/otlp v0.11.0 // indirect
+	golang.org/x/crypto v0.0.0-20220307211146-efcb8507fb70 // indirect
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
+	golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200609130330-bd2cb7843e1b // indirect
+	google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/fsnotify.v1 v1.4.7 // indirect
+	gopkg.in/square/go-jose.v2 v2.4.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -46,12 +46,15 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/eapache/go-resiliency v1.2.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
+github.com/edwarnicke/exechelper v1.0.1/go.mod h1:/T271jtNX/ND4De6pa2aRy2+8sNtyCDB1A2pp4M+fUs=
 github.com/edwarnicke/exechelper v1.0.2 h1:dD49Ui2U0FBFxxhalnKw6vLS0P0TkgnXBRvKL/xmC5w=
 github.com/edwarnicke/exechelper v1.0.2/go.mod h1:/T271jtNX/ND4De6pa2aRy2+8sNtyCDB1A2pp4M+fUs=
 github.com/edwarnicke/govpp v0.0.0-20220311182453-f32f292e0e91 h1:iDVzIaYZjTg+hQGcDeOLJZc+5VfKvW7ye54EFX3CRQA=
 github.com/edwarnicke/govpp v0.0.0-20220311182453-f32f292e0e91/go.mod h1:kHDnxA+SSNFeMEHz7xvhub1zvx4mOTRlWWRCay2n5NM=
 github.com/edwarnicke/grpcfd v1.1.2 h1:2b8kCABQ1+JjSKGDoHadqSW7whCeTXMqtyo6jmB5B8k=
 github.com/edwarnicke/grpcfd v1.1.2/go.mod h1:rHihB9YvNMixz8rS+ZbwosI2kj65VLkeyYAI2M+/cGA=
+github.com/edwarnicke/imports-gen v1.1.2 h1:7GHc07PTo8kRzdOVJdQEuxYic3wg5SYGHOg5qrY3PEk=
+github.com/edwarnicke/imports-gen v1.1.2/go.mod h1:aCSe8SMtEh1O51cS5s3vxK6Lu3sPMkQwAqnye8AROwo=
 github.com/edwarnicke/log v1.0.0 h1:T6uRNCmR99GTt/CpRr2Gz8eGW8fm0HMThDNGdNxPaGk=
 github.com/edwarnicke/log v1.0.0/go.mod h1:eWsQQlQ0IU5wHlJvyXFH3dS8s2g9GzN7JnXodo6yaIY=
 github.com/edwarnicke/serialize v0.0.0-20200705214914-ebc43080eecf/go.mod h1:XvbCO/QGsl3X8RzjBMoRpkm54FIAZH5ChK2j+aox7pw=
@@ -443,7 +446,6 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.zx2c4.com/wireguard v0.0.20200121 h1:vcswa5Q6f+sylDfjqyrVNNrjsFUUbPsgAQTBCAg/Qf8=
 golang.zx2c4.com/wireguard v0.0.20200121/go.mod h1:P2HsVp8SKwZEufsnezXZA4GRX/T49/HlU7DGuelXsU4=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200609130330-bd2cb7843e1b h1:l4mBVCYinjzZuR5DtxHuBD6wyd4348TGiavJ5vLrhEc=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200609130330-bd2cb7843e1b/go.mod h1:UdS9frhv65KTfwxME1xE8+rHYoFpbm36gOud1GhBe9c=

--- a/tools.go
+++ b/tools.go
@@ -14,8 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package imports is used for generating list of imports to optimize use of docker build cache
-package imports
+//go:build tools
 
-//go:generate bash -c "rm -rf imports*.go"
-//go:generate go run -exec "env GOOS=linux" github.com/edwarnicke/imports-gen
+package tools
+
+import (
+	_ "github.com/edwarnicke/imports-gen"
+)


### PR DESCRIPTION
https://github.com/networkservicemesh/sdk/issues/1264

* Update Dockerfiles to use `go:1.18-bullseye` instead of `go:1.16-buster`.
* In GitHub workflow yamls, update go to 1.18 and golangci-lint to 1.45.2.
* Update `go.mod` files to use `go 1.18`.
* Replace deprecated linters: `golint` -> `revive`, `scopelint` -> exportloopref`.
* Fix `goheader` linting rule configuration.
* Fix linter issues introduced by the new golangci-lint version.